### PR TITLE
Use addres of slot instead of a array index and messageId.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -88,10 +88,10 @@ func NewClient(conn *amqp.Connection, serviceName string, defaultTTL int64) (*Cl
 func (c *Client) start() {
     go func() {
         for d := range c.deliveryChannel {
-            index := unmarshallCorrelationID(d.CorrelationId)
+            address := unmarshallCorrelationID(d.CorrelationId)
 
             func() {
-                slot := c.getSlot(index)
+                slot := c.getSlot(address)
 
                 var jsonResponse interface{}
                 var err error
@@ -201,14 +201,13 @@ func (c *Client) CallVoid(method string, args ...interface{}) {
     }
 }
 
-
 // Close the client and AMQP chanel.
 func (c *Client) Close() {
     c.channel.Close()
 }
 
-func (c *Client) getSlot(index uintptr) *slot {
-    return (*slot)(unsafe.Pointer(uintptr(index)))
+func (c *Client) getSlot(address uintptr) *slot {
+    return (*slot)(unsafe.Pointer(uintptr(address)))
 }
 
 func (c *Client) getFreeSlot()(*slot, error){

--- a/client/client.go
+++ b/client/client.go
@@ -72,8 +72,6 @@ func NewClient(conn *amqp.Connection, serviceName string, defaultTTL int64) (*Cl
         return nil, err
     }
 
-    //slots := make([]slot, 20000)
-
     c := &Client{
         serviceName,
         defaultTTL,

--- a/example_server.go
+++ b/example_server.go
@@ -17,7 +17,7 @@ func main() {
 
     defer broker.Close()
 
-    userService, err := server.NewServer(broker, "UserService", 4)
+    userService, err := server.NewServer(broker, "UserService", 150)
 
     if err != nil {
         fmt.Printf("Error creating server")

--- a/message/message.go
+++ b/message/message.go
@@ -1,6 +1,40 @@
 package message
 
+import (
+	"encoding/binary"
+	"unsafe"
+	"fmt"
+)
+
 type MessageBody struct {
     Method  string          `json:"method"`
     Args    []interface{}   `json:"args"`
+}
+
+func UintptrToBytes(value uintptr) []byte {
+	size := unsafe.Sizeof(value)
+	b := make([]byte, size)
+	switch size {
+	case 4:
+		binary.LittleEndian.PutUint32(b, uint32(value))
+	case 8:
+		binary.LittleEndian.PutUint64(b, uint64(value))
+	default:
+		panic(fmt.Sprintf("unknown uintptr size: %v", size))
+	}
+	return b
+}
+
+func BytesToUintptr(bytes []byte) uintptr {
+	var intptr uintptr
+	size := unsafe.Sizeof(intptr)
+	switch size {
+	case 4:
+		intptr = uintptr(binary.LittleEndian.Uint32(bytes))
+	case 8:
+		intptr = uintptr(binary.LittleEndian.Uint64(bytes))
+	default:
+		panic(fmt.Sprintf("unknown uintptr size: %v", size))
+	}
+	return intptr
 }

--- a/server/server.go
+++ b/server/server.go
@@ -129,7 +129,7 @@ func (s *Server) start() {
                         return
                     }
 
-                    fmt.Println("Sending response: ", response)
+                    fmt.Printf("Sending response to %s: %s\n", d.CorrelationId, response)
 
                     err = s.channel.Publish(
                         "",


### PR DESCRIPTION
The memory address of slot is guaranteed by the OS, porthos client no longer need to worry about concurrency and unique id to identify messages.
