### PR TITLE
Fix travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.6
-  - 1.7
+  - 1.8
+  - 1.9
   - tip
 install:
   - go get github.com/streadway/amqp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.9
 
 RUN apt-get update && apt-get install -y wget
 RUN wget https://github.com/jwilder/dockerize/releases/download/v0.2.0/dockerize-linux-amd64-v0.2.0.tar.gz


### PR DESCRIPTION
[github.com/streadway/amqp](github.com/streadway/amqp) does not support go 1.6 and 1.7.